### PR TITLE
DGDG-7-retrieve-list-of-country-codes-in-api-instance

### DIFF
--- a/docs/source/country.rst
+++ b/docs/source/country.rst
@@ -22,6 +22,19 @@ The object ``germany`` is an instance of the class ``Country`` represented by th
     Country : Germany
     <class 'the_datagarden.api.regions.country.Country'>
 
+The country object also be retrieved using is ISO 3166-1 alpha-2 country code (both upper and lower case are supported).
+
+.. code-block:: python
+
+    # Retrieving the country object for Germany and United States using their ISO 3166-1 alpha-2 country codes
+    >>> from the_datagarden import TheDataGardenAPI
+    >>> my_datagarden_api = TheDataGardenAPI()
+    >>> germany = my_datagarden_api.DE
+    >>> united_states = my_datagarden_api.us
+    >>> print(germany)
+    >>> print(united_states)
+    Country : Germany
+    Country : United States of America
 
 The country's meta data
 -----------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,12 +14,12 @@ retrieve data for a specific continent, country or subregion easily by calling t
 .. code-block:: python
 
     # initialize a country object and retrieve the demographics attribute
-    >>> nl = the_datagarden_api.netherlands
+    >>> nl = the_datagarden_api.netherlands # or nl = the_datagarden_api.NL
     >>> nl_demographics = nl.demographics()
     TheDataGardenRegionalDataModel : Demographics : (count=5)
 
 Object ``nl_demographics`` will now hold 5 records containing demographic data for the Netherlands for a specific set
-of periods (by defaut records with yearly data are retrieved). You can convert ``nl_demographics`` to a pandas or polars so
+of periods (by default records with yearly data are retrieved). You can convert ``nl_demographics`` to a pandas or polars so
 that you can work with the data in a tabular format.
 
 .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "the-datagarden"
-version = "1.1.2"
+version = "1.1.3"
 description = "Public data made easy."
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/the_datagarden/api/base/__init__.py
+++ b/src/the_datagarden/api/base/__init__.py
@@ -148,8 +148,8 @@ class TheDataGardenAPI(BaseDataGardenAPI):
 
     def __getattr__(self, attr: str):
         for _, endpoints in self.DYNAMIC_ENDPOINTS.items():
-            if attr in endpoints:
-                return endpoints[attr]
+            if attr.lower() in endpoints:
+                return endpoints[attr.lower()]
 
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
 
@@ -183,7 +183,7 @@ class TheDataGardenAPI(BaseDataGardenAPI):
                         continent_method_name: Continent(
                             url=self._create_url_extension([URLExtension.CONTINENT + continent["name"]]),
                             api=self,
-                            name=continent["name"],
+                            name=continent["name"].lower(),
                         ),
                     }
                 )
@@ -197,13 +197,18 @@ class TheDataGardenAPI(BaseDataGardenAPI):
                 return None
             for country in self._records_from_paginated_api_response(countries):
                 country_method_name = country["name"].lower().replace(" ", "_")
+                country_code = country["iso_cc_2"].lower()
+                continent = country["parent_region"].lower()
+                country = Country(
+                    url=self._create_url_extension([URLExtension.COUNTRY + country["name"]]),
+                    api=self,
+                    name=country["name"],
+                    continent=continent,
+                )
                 self.DYNAMIC_ENDPOINTS[DynamicEndpointCategories.COUNTRIES].update(
                     {
-                        country_method_name: Country(
-                            url=self._create_url_extension([URLExtension.COUNTRY + country["name"]]),
-                            api=self,
-                            name=country["name"],
-                        ),
+                        country_method_name: country,
+                        country_code: country,
                     }
                 )
 

--- a/src/the_datagarden/api/regions/base/__init__.py
+++ b/src/the_datagarden/api/regions/base/__init__.py
@@ -48,13 +48,14 @@ class Region:
     def __repr__(self):
         return f"{self.__class__.__name__} : {self._name}"
 
-    def __init__(self, url: str, api: BaseApi, name: str):
+    def __init__(self, url: str, api: BaseApi, name: str, continent: str | None = None):
         self._region_url = url
         self._api = api
         self._available_models: dict = {}
         self._model_data_storage: dict[str, TheDataGardenRegionalDataModel] = {}
         self._geojsons = TheDataGardenRegionGeoJSONModel(api=api, region_url=url)
         self._name = name
+        self._continent = continent
 
     def __getattr__(self, attr: str):
         if attr in self.available_model_names:


### PR DESCRIPTION
Allow to use iso country code to be used to retrieve a country object

my_datagarden_api.nl 

now returns the same result as 

my_datagarden_api.netherlands

